### PR TITLE
Remove the application label

### DIFF
--- a/unity-ads/AndroidManifest.xml
+++ b/unity-ads/AndroidManifest.xml
@@ -4,8 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <application
-        android:label="@string/lib_name">
+    <application>
         <activity
   		    android:name="com.unity3d.ads.android.view.UnityAdsFullscreenActivity" 
           	android:configChanges="fontScale|keyboard|keyboardHidden|locale|mnc|mcc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|uiMode|touchscreen"


### PR DESCRIPTION
Since this is a SDK it does not need an app label
nor should it have one as it prevents users from
being able to set an application label for their 
app.
